### PR TITLE
Set minimum market expiry time to 10 days

### DIFF
--- a/programs/openbook-twap/src/lib.rs
+++ b/programs/openbook-twap/src/lib.rs
@@ -22,7 +22,7 @@ const TWAP_MARKET: &[u8] = b"twap_market";
 
 declare_id!("twAP5sArq2vDS1mZCT7f4qRLwzTfHvf5Ay5R5Q5df1m");
 
-pub const TEN_DAYS_IN_SECONDS: i64 = 10  * 24 * 60 * 60;
+pub const TEN_DAYS_IN_SECONDS: i64 = 10 * 24 * 60 * 60;
 
 #[account]
 pub struct TWAPMarket {
@@ -379,7 +379,10 @@ pub mod openbook_twap {
         let twap_market = &mut ctx.accounts.twap_market;
 
         let current_time = clock::Clock::get().unwrap().unix_timestamp as i64;
-        require!(market.time_expiry > current_time + TEN_DAYS_IN_SECONDS, OpenBookTWAPError::InsufficentExpiryTime);
+        require!(
+            market.time_expiry > current_time + TEN_DAYS_IN_SECONDS,
+            OpenBookTWAPError::InsufficentExpiryTime
+        );
         require!(
             market.open_orders_admin == twap_market.key(),
             OpenBookTWAPError::InvalidOpenOrdersAdmin

--- a/programs/openbook-twap/src/lib.rs
+++ b/programs/openbook-twap/src/lib.rs
@@ -378,7 +378,7 @@ pub mod openbook_twap {
         let market = ctx.accounts.market.load()?;
         let twap_market = &mut ctx.accounts.twap_market;
 
-        let current_time = clock::Clock::get().unwrap().unix_timestamp as i64;
+        let current_time = Clock::get().unwrap().unix_timestamp as i64;
         require!(
             market.time_expiry > current_time + TEN_DAYS_IN_SECONDS,
             OpenBookTWAPError::InsufficentExpiryTime

--- a/programs/openbook-twap/src/lib.rs
+++ b/programs/openbook-twap/src/lib.rs
@@ -22,6 +22,8 @@ const TWAP_MARKET: &[u8] = b"twap_market";
 
 declare_id!("twAP5sArq2vDS1mZCT7f4qRLwzTfHvf5Ay5R5Q5df1m");
 
+pub const TEN_DAYS_IN_SECONDS: i64 = 10  * 24 * 60 * 60;
+
 #[account]
 pub struct TWAPMarket {
     pub market: Pubkey,
@@ -376,7 +378,8 @@ pub mod openbook_twap {
         let market = ctx.accounts.market.load()?;
         let twap_market = &mut ctx.accounts.twap_market;
 
-        require!(market.time_expiry == 0, OpenBookTWAPError::NonZeroExpiry);
+        let current_time = clock::Clock::get().unwrap().unix_timestamp as i64;
+        require!(market.time_expiry > current_time + TEN_DAYS_IN_SECONDS, OpenBookTWAPError::InsufficentExpiryTime);
         require!(
             market.open_orders_admin == twap_market.key(),
             OpenBookTWAPError::InvalidOpenOrdersAdmin
@@ -693,8 +696,8 @@ pub enum OpenBookTWAPError {
         "The `close_market_admin` of the underlying market must be equal to the `TWAPMarket` PDA"
     )]
     InvalidCloseMarketAdmin,
-    #[msg("Market must not expire (have `time_expiry` == 0)")]
-    NonZeroExpiry,
+    #[msg("Market must expire a minimum of 10 days from now")]
+    InsufficentExpiryTime,
     #[msg(
         "Oracle-pegged trades mess up the TWAP so oracles and oracle-pegged trades aren't allowed"
     )]

--- a/tests/openbook-twap.ts
+++ b/tests/openbook-twap.ts
@@ -110,6 +110,10 @@ describe("openbook-twap", () => {
       openbookTwap.programId
     );
 
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    const elevenDaysInSeconds = 11 * 24 * 60 * 60;
+    const expiryTime = new BN(currentTimeInSeconds + elevenDaysInSeconds);
+
     let market = await openbook.createMarket(
       payer,
       "META/USDC",
@@ -119,7 +123,7 @@ describe("openbook-twap", () => {
       new BN(1e9),
       new BN(0),
       new BN(0),
-      new BN(0),
+      expiryTime,
       null,
       null,
       twapMarket,


### PR DESCRIPTION
Allows for rent to be retrieved from markets.

Yes, there are other ways to do this but this way requires the least amount of code changes to autocrat and openbook-twap. It comes a some small risk that no one runs the final crank of the TWAP calculation after the proposal has ended. If no one runs the final crank and the market expires then the conditional vault is locked. Seven days or more should allow for enough for this to happen. 

Allowing for a fallback condition in the conditional vault or autocrat in the future might be worth considering. Also covers the case where the proposal instruction cannot be executed.